### PR TITLE
Konflux build pipeline service account migration

### DIFF
--- a/.tekton/applio-pull-request.yaml
+++ b/.tekton/applio-pull-request.yaml
@@ -466,7 +466,8 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-applio
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/applio-push.yaml
+++ b/.tekton/applio-push.yaml
@@ -463,7 +463,8 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-applio
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION

## Build pipeline Service Account migration

This PR changes Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.
Please merge the Service Account update to avoid broken builds when deprected "appstudio-pipeline" Service Account is removed.
